### PR TITLE
Mail new users

### DIFF
--- a/src/server/trpc/router/mail.ts
+++ b/src/server/trpc/router/mail.ts
@@ -1,6 +1,86 @@
 import { z } from 'zod';
 import { router, publicProcedure } from '../trpc';
 import { createTransport } from 'nodemailer';
+import { Language } from 'hooks/use-language';
+
+interface MailText {
+  subject?: string;
+  text?: string;
+  html?: string;
+}
+
+export const mailNewUser = async (email: string, language: Language) => {
+  const url = process.env.NEXTAUTH_URL;
+  const mailText: Record<Language, MailText> = {
+    sv: {
+      subject: 'Välkommen till Blindtarmen!',
+      text: `Ett konto har skapats för dig på Blindtarmen, vilket är Bleckhornens interna hemsida där man anmäler sig till spelningar och annat!\n\nDu kan nu logga in med mailaddressen som detta mailet skickades till på ${url}!`,
+      html: `
+        Ett konto har skapats för dig på Blindtarmen, vilket är Bleckhornens egensnickrade hemsida där man anmäler sig till spelningar och annat!
+        <br />
+        <br />
+        Du kan nu logga in med mailadressen som detta mailet skickades till.
+        <br />
+        <br />
+        <br />
+        <a
+          href="${url}"
+          target="_blank"
+          style="
+            font-size: 18px;
+            color: #fafffc;
+            text-decoration: none;
+            border-radius: 5px;
+            padding: 10px 20px;
+            border: 0;
+            display: inline-block;
+            font-weight: bold;
+            background-color: #ce0c00
+          "
+        >
+          Ta mig till Blindtarmen!
+        </a>
+      `,
+    },
+    en: {
+      subject: 'Welcome to Blindtarmen!',
+      text: `An account has been created for you at Blindtarmen, which is Bleckhornen's internal website where you sign up for gigs and the like!\n\nYou can now log in using the email address where this mail was sent at ${url}!`,
+      html: `
+        An account has been created for you at Blindtarmen, which is Bleckhornen's very own website where you sign up for gigs and the like!
+        <br />
+        <br />
+        You can now log in using the email address where this mail was sent.
+        <br />
+        <br />
+        <br />
+        <a
+          href="${url}"
+          target="_blank"
+          style="
+            font-size: 18px;
+            color: #fafffc;
+            text-decoration: none;
+            border-radius: 5px;
+            padding: 10px 20px;
+            border: 0;
+            display: inline-block;
+            font-weight: bold;
+            background-color: #ce0c00
+          "
+        >
+          Take me to Blindtarmen!
+        </a>
+      `,
+    },
+  };
+
+  const mailTransport = createTransport(process.env.EMAIL_SERVER);
+  await mailTransport.sendMail({
+    from: `"AMC Bleckhornen" <${process.env.EMAIL_FROM}>`,
+    to: email,
+    ...mailText[language],
+  });
+};
 
 export const mailRouter = router({
   application: publicProcedure


### PR DESCRIPTION
If a new user is created, mail the new user in their preferred language with an introduction and a link to Blindtarmen.

Resolves #335.