### PR TITLE
Update section leader permission role when updating section leaders

### DIFF
--- a/src/app/admin/permissions/edit/[id]/roleholder-list.tsx
+++ b/src/app/admin/permissions/edit/[id]/roleholder-list.tsx
@@ -41,55 +41,72 @@ const AdminRoleHolderList = ({ role }: AdminRoleHolderListProps) => {
     },
   });
 
+  const isSectionLeaderRole = role.name === 'Stämledare';
+
   return (
     <div className='flex max-w-md flex-col'>
       {role.corpsii.map((corps) => (
         <div key={corps.id}>
           <div className='flex gap-4'>
             <h5 className='grow'>{detailedName(corps)}</h5>
-            <ActionIcon
-              variant='subtle'
-              onClick={() => {
-                if (
-                  !confirm(
-                    'Är du säker på att du vill ta bort behörighetsroll från corps?',
-                  )
-                ) {
-                  return;
-                }
-                removeRole.mutate({
-                  corpsId: corps.id,
-                  roleId: role.id,
-                });
-              }}
-            >
-              <IconTrash />
-            </ActionIcon>
+            {!isSectionLeaderRole && (
+              <ActionIcon
+                variant='subtle'
+                onClick={() => {
+                  if (
+                    !confirm(
+                      'Är du säker på att du vill ta bort behörighetsroll från corps?',
+                    )
+                  ) {
+                    return;
+                  }
+                  removeRole.mutate({
+                    corpsId: corps.id,
+                    roleId: role.id,
+                  });
+                }}
+              >
+                <IconTrash />
+              </ActionIcon>
+            )}
           </div>
         </div>
       ))}
-      <form
-        className='flex items-end gap-4'
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!corpsId) {
-            return;
-          }
-          addRole.mutate({
-            corpsId,
-            roleId: role.id,
-          });
-        }}
-      >
-        <SelectCorps
-          label={lang('Lägg till corps', 'Add corps')}
-          className='grow'
-          onChange={(p) => {
-            setCorpsId(p);
+      {isSectionLeaderRole && (
+        <>
+          <div className='h-4' />
+          <h6 className='italic'>
+            {lang(
+              'Denna listan är synkad med listan i "Stämledare"-fliken under "Admin". Om du vill ändra vilka som är stämledare, gör det där.',
+              'This list is synced with the list at "Section Leaders" under "Admin". If you want to change who are section leaders, do that there.',
+            )}
+          </h6>
+        </>
+      )}
+      {!isSectionLeaderRole && (
+        <form
+          className='flex items-end gap-4'
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!corpsId) {
+              return;
+            }
+            addRole.mutate({
+              corpsId,
+              roleId: role.id,
+            });
           }}
-        />
-        <Button type='submit'>{lang('Lägg till', 'Add')}</Button>
-      </form>
+        >
+          <SelectCorps
+            label={lang('Lägg till corps', 'Add corps')}
+            className='grow'
+            onChange={(p) => {
+              setCorpsId(p);
+            }}
+          />
+          <Button type='submit'>{lang('Lägg till', 'Add')}</Button>
+        </form>
+      )}
     </div>
   );
 };

--- a/src/app/gig/[id]/signup-list/index.tsx
+++ b/src/app/gig/[id]/signup-list/index.tsx
@@ -463,7 +463,7 @@ const SignupList = ({ gigId }: SignupListProps) => {
         </div>
       )}
       {noList.length > 0 && (
-        <Restricted permissions='manageAttendance'>
+        <Restricted permissions='viewAttendance'>
           <div>
             <h3>
               {lang('Dessa', 'These')}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -92,7 +92,7 @@ const adminTab: NavbarLinkGroup = {
       permission: 'managePermissions',
     },
     {
-      label: lang('Sektioner', 'Sections'),
+      label: lang('Stämledare', 'Section Leaders'),
       href: '/admin/section',
       icon: <IconMicrophone2 />,
       permission: 'manageSections',

--- a/src/server/trpc/router/section.ts
+++ b/src/server/trpc/router/section.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { router, restrictedProcedure } from '../trpc';
+import { filterNone } from 'utils/array';
 
 export const sectionRouter = router({
   getSectionLeader: restrictedProcedure('manageSections')
@@ -29,6 +30,7 @@ export const sectionRouter = router({
     .input(z.object({ sectionId: z.number(), corpsId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const { sectionId, corpsId } = input;
+
       const section = await ctx.prisma.section.update({
         where: { id: sectionId },
         data: {
@@ -39,6 +41,73 @@ export const sectionRouter = router({
           },
         },
       });
+
+      // Sync section leader permission roles
+      const sectionLeaderRole = await ctx.prisma.role.findUnique({
+        where: {
+          name: 'Stämledare',
+        },
+      });
+      if (sectionLeaderRole) {
+        // Remove "Stämledare" role from all corps
+        const oldSectionLeaders = await ctx.prisma.corps.findMany({
+          select: {
+            id: true,
+          },
+          where: {
+            roles: {
+              some: {
+                id: sectionLeaderRole.id,
+              },
+            },
+          },
+        });
+        await Promise.all(
+          oldSectionLeaders.map((leader) =>
+            ctx.prisma.corps.update({
+              where: {
+                id: leader.id,
+              },
+              data: {
+                roles: {
+                  disconnect: {
+                    id: sectionLeaderRole.id,
+                  },
+                },
+              },
+            }),
+          ),
+        );
+
+        // Readd all "Stämledare" roles
+        const sections = await ctx.prisma.section.findMany({
+          select: {
+            leader: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        });
+        const leaders = filterNone(sections.map((section) => section.leader));
+        await Promise.all(
+          leaders.map((leader) =>
+            ctx.prisma.corps.update({
+              where: {
+                id: leader.id,
+              },
+              data: {
+                roles: {
+                  connect: {
+                    id: sectionLeaderRole.id,
+                  },
+                },
+              },
+            }),
+          ),
+        );
+      }
+
       return section;
     }),
 });

--- a/src/utils/permission.ts
+++ b/src/utils/permission.ts
@@ -1,4 +1,7 @@
 // Defines the permissions that can be assigned to a corps or role.
+
+import { Context } from 'server/trpc/context';
+
 // NOTE: Keep this in sync with the permissions in the database!
 export const ALL_PERMISSIONS = [
   'manageGigs',
@@ -11,5 +14,22 @@ export const ALL_PERMISSIONS = [
   'viewFoodPrefs',
   'manageStreck',
   'viewStreck',
+  'viewAttendance',
 ] as const;
 export type Permission = (typeof ALL_PERMISSIONS)[number];
+
+export const addNewPermissions = async (ctx: Context) => {
+  const existingPermissions = (await ctx.prisma.permission.findMany()).map(
+    (p) => p.name,
+  );
+
+  for (const permission of ALL_PERMISSIONS) {
+    if (!existingPermissions.includes(permission)) {
+      await ctx.prisma.permission.create({
+        data: {
+          name: permission,
+        },
+      });
+    }
+  }
+};


### PR DESCRIPTION
When changing a section leader, also sets permission role "Stämledare" for all section leaders so that they are always in sync.