### PR TITLE
Make gigs with NaN start time be all day events

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -105,7 +105,14 @@ export const getGigCalenderDates = (gig: {
   const start = parseGigTime(gig.date, gig.start);
 
   if (!meetup && !start) {
-    return undefined;
+    const startOfDay = new Date(gig.date);
+    startOfDay.setUTCHours(0 - getSwedenHourOffset(startOfDay));
+    const endOfDay = new Date(gig.date);
+    endOfDay.setUTCHours(24 - getSwedenHourOffset(endOfDay));
+    return {
+      start: startOfDay,
+      end: endOfDay,
+    };
   } else if (meetup && !start) {
     return {
       start: meetup,


### PR DESCRIPTION
Changes so gigs that for instance say "kväll" as starting time show up as events from 00:00 to 24:00. 
Both calenders i tested on mark them as "all-day" events that show up at the top of a day